### PR TITLE
[FIX]web_translate_dialog: stop automatic copy translation

### DIFF
--- a/web_translate_dialog/models/translation.py
+++ b/web_translate_dialog/models/translation.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
+from openerp.models import BaseModel
 from openerp import api, models, _
+
+@api.v7
+def copy_translations(self, cr, uid, old_id, new_id, context=None):
+    return
+
+BaseModel.copy_translations = copy_translations
 
 
 class IRTranslation(models.Model):


### PR DESCRIPTION
Hi Kitti,

Ref: /issues/669

If translation is copied, it should be a lot more problem.
For example, case product name.
**Steps:**  

1.  Existing record with TH = กกกก and EN = AAAA
2.     User in TH mode, copy and change only กกกก -> ขขขขขข
3.     Now, in the system if anyone in EN mode, will see 2 records with EN = AAAA
4.     This could ensure a lot of mistake. Better way is not to copy translation at all.

Thanks, 
Mustufa