### PR TITLE
#4416 - mis_builder

### DIFF
--- a/mis_builder/report/report_mis_report_instance.xml
+++ b/mis_builder/report/report_mis_report_instance.xml
@@ -31,9 +31,7 @@
                 <tbody>
                   <tr t-foreach="docs_computed[o.id]['content']" t-as="c">
                     <td t-att-style="c_value['default_style']">
-                      <div class="text-left">
                         <t t-esc="c_value['kpi_name']"/>
-                      </div>
                     </td>
                     <t t-foreach="c_value['cols']" t-as="value">
                       <td t-att-style="c_value['default_style']">


### PR DESCRIPTION
Issue: https://mobileapp.nstda.or.th/redmine/issues/4416
Deployment: Update This Only Module: mis_builder


กรณีกำหนดค่า default_css_style = font-weight: bold; text-align: right; สามารถแสดงผลใน PDF ให้เป็น "ตัวหนา และ ชิดทางด้านขวา" ได้

XLSX: https://github.com/pabi2/pb2_addons/pull/1834

![Selection_198](https://user-images.githubusercontent.com/52144935/79195954-5ca92700-7e59-11ea-8237-7c77a2d4d2bc.png)
![Selection_197](https://user-images.githubusercontent.com/52144935/79195953-5adf6380-7e59-11ea-9c5a-1a80d8aedeec.png)
